### PR TITLE
CodeMirror extension: addon/hint/Code snippets

### DIFF
--- a/codemirror-extension/addon/hint/templates-hint.js
+++ b/codemirror-extension/addon/hint/templates-hint.js
@@ -102,6 +102,7 @@
           
         if (templateVar == "cursor")
         {
+            cm.replaceRange("", pos.from, {line: pos.from.line, ch: pos.from.ch + 2})
             cm.setSelection(pos.from);
             uninstall(cm);
         }
@@ -190,8 +191,8 @@
         if (token.variable) {
           if (!isSpecialVar(token.variable)) {
             content += token.variable;
-            var from = Pos(data.from.line + line, data.from.ch + token.x);
-            var to = Pos(data.from.line + line, data.from.ch + token.x
+            var from = Pos(data.from.line + line, token.x);
+            var to = Pos(data.from.line + line, token.x
                 + token.variable.length);
             var selectable = variables[token.variable] != false;
             markers.push({
@@ -203,10 +204,10 @@
             variables[token.variable] = false;
           }
             else {
-                content += " ";
-                var from = Pos(data.from.line + line, data.from.ch + token.x);
-                var to = Pos(data.from.line + line, data.from.ch + token.x
-                    + 1);
+                content += "//";
+                var from = Pos(data.from.line + line, token.x);
+                var to = Pos(data.from.line + line, token.x
+                    + 2);
                 var selectable = variables[token.variable] != false;
                 markers.push({
                   from : from,
@@ -229,7 +230,27 @@
       var from = data.from;
       var to = data.to;
       cm.replaceRange(content, from, to);
-
+      
+      var lines = content.split("\n");
+      
+      for (x = 0; x < lines.length; x++) 
+      {        
+        var targetLine = from.line + x;
+        
+        cm.indentLine(targetLine);
+        var line = cm.getLine(targetLine);
+        var deltaIndent = line.length - lines[x].length;
+        
+        for (y = 0; y < markers.length; y++)
+        {
+          if (markers[y].from.line == targetLine)
+          {
+            markers[y].from.ch += deltaIndent;
+            markers[y].to.ch += deltaIndent;
+          }
+        }
+      }
+      
       for ( var i = 0; i < markers.length; i++) {
         var marker = markers[i], from = marker.from, to = marker.to;
         var markText = cm.markText(from, to, {


### PR DESCRIPTION
Stop jumping between variables on ${cursor}

Should do the job. I also modified additional files, like templates and I removed unused code, to make it easier for me to use.

The reason I had to put it in another repository is to make it work for Haxe mode in my IDE with minimal additional code. (I decided to stop using Tern in my IDE, because it's too complicated for me, and has too much JavaScript specific things, it's much easier to just use CM addons for it).

In your CodeMirror-XQuery demo, indentation works fine, in my Haxe mode, it's doesn't take in account it.
Maybe you know how to fix it?
