### PR TITLE
Added function to replace previously added templates

### DIFF
--- a/codemirror-extension/addon/hint/templates-hint.js
+++ b/codemirror-extension/addon/hint/templates-hint.js
@@ -398,5 +398,16 @@
       });
     }
   }
+  
+  CodeMirror.templatesHint.replaceTemplates = function(templates) {
+    var context = templates.context;
+    if (context) {
+      var list = [];
+      templatesMap[context] = list;
+      templates.templates.forEach(function(template) {
+        list.push(new Template(template));
+      });
+    }
+  }
 
 })();


### PR DESCRIPTION
Currently working on an app where templates are added multiple times, and found the need to replace all of them with new ones, and could not find any functionality that did this.
